### PR TITLE
Fix some issues in access.asd

### DIFF
--- a/access.asd
+++ b/access.asd
@@ -1,24 +1,18 @@
 ;; -*- lisp -*-
 
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (unless (find-package :access.system)
-    (defpackage :access.system (:use :common-lisp :asdf))))
-
-(in-package :access.system)
-
-(defsystem :access
-  :description "A library providing functions that unify data-structure access for Common Lisp:
-      access and (setf access)"
+(defsystem "access"
+  :description "A library providing functions that unify data-structure access for Common Lisp: access and (setf access)"
   :licence "BSD"
   :author "Acceleration.net, Russ Tyndall, Nathan Bird, Ryan Davis"
   :version "1.5.0"
   :serial t
   :components ((:file "access")
                (:file "arg-list-manipulation"))
-  :depends-on (:iterate :closer-mop :alexandria :anaphora :cl-interpol)
-  :in-order-to ((test-op (load-op :access-test))))
+  :depends-on ("iterate" "closer-mop" "alexandria" "anaphora" "cl-interpol")
+  :in-order-to ((test-op (load-op "access/test")))
+  :perform (test-op (op c) (symbol-call '#:access-test '#:run-all-tests)))
 
-(defsystem :access-test
+(defsystem "access/test"
   :description "Tests for the access library"
   :licence "BSD"
   :version "1.5.0"
@@ -28,9 +22,4 @@
                         :serial t
                         :components ((:file "access")
                                      (:file "arg-list-manipulation"))))
-  :depends-on (:access :lisp-unit2))
-
-(defmethod asdf:perform ((o asdf:test-op) (c (eql (find-system :access))))
-  (asdf:oos 'asdf:load-op :access-test)
-  (let ((*package* (find-package :access-test)))
-    (eval (read-from-string "(run-all-tests)"))))
+  :depends-on ("access" "lisp-unit2"))

--- a/access.asd
+++ b/access.asd
@@ -8,7 +8,7 @@
   :serial t
   :components ((:file "access")
                (:file "arg-list-manipulation"))
-  :depends-on ("iterate" "closer-mop" "alexandria" "anaphora" "cl-interpol")
+  :depends-on ("iterate" "closer-mop" "alexandria" "anaphora" "cl-ppcre")
   :in-order-to ((test-op (load-op "access/test")))
   :perform (test-op (op c) (symbol-call '#:access-test '#:run-all-tests)))
 


### PR DESCRIPTION
Specifically, this fixes #13 and replaces the dependency on cl-interpol with cl-ppcre. I cannot find any use of cl-interpol in access.