### PR TITLE
Remove dependency on 'anaphora' + some portability fixes

### DIFF
--- a/access.asd
+++ b/access.asd
@@ -1,24 +1,18 @@
 ;; -*- lisp -*-
 
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (unless (find-package :access.system)
-    (defpackage :access.system (:use :common-lisp :asdf))))
-
-(in-package :access.system)
-
-(defsystem :access
-  :description "A library providing functions that unify data-structure access for Common Lisp:
-      access and (setf access)"
+(defsystem "access"
+  :description "A library providing functions that unify data-structure access for Common Lisp: access and (setf access)"
   :licence "BSD"
   :author "Acceleration.net, Russ Tyndall, Nathan Bird, Ryan Davis"
   :version "1.5.0"
   :serial t
   :components ((:file "access")
                (:file "arg-list-manipulation"))
-  :depends-on (:iterate :closer-mop :alexandria :anaphora :cl-interpol)
-  :in-order-to ((test-op (load-op :access-test))))
+  :depends-on ("iterate" "closer-mop" "alexandria" "anaphora" "cl-interpol")
+  :in-order-to ((test-op (load-op "access/test")))
+  :perform (test-op (op c) (symbol-call '#:access-test '#:run-all-tests)))
 
-(defsystem :access-test
+(defsystem "access/test"
   :description "Tests for the access library"
   :licence "BSD"
   :version "1.5.0"
@@ -28,9 +22,4 @@
                         :serial t
                         :components ((:file "access")
                                      (:file "arg-list-manipulation"))))
-  :depends-on (:access :lisp-unit2))
-
-(defmethod asdf:perform ((o asdf:test-op) (c (eql (find-system :access))))
-  (asdf:oos 'asdf:load-op :access-test)
-  (let ((*package* (find-package :access-test)))
-    (eval (read-from-string "(run-all-tests)"))))
+  :depends-on ("access" "lisp-unit2"))

--- a/access.asd
+++ b/access.asd
@@ -8,7 +8,7 @@
   :serial t
   :components ((:file "access")
                (:file "arg-list-manipulation"))
-  :depends-on ("iterate" "closer-mop" "alexandria" "anaphora" "cl-interpol")
+  :depends-on ("iterate" "closer-mop" "alexandria" "anaphora" "cl-ppcre")
   :in-order-to ((test-op (load-op "access/test")))
   :perform (test-op (op c) (symbol-call '#:access-test '#:run-all-tests)))
 

--- a/access.asd
+++ b/access.asd
@@ -8,7 +8,7 @@
   :serial t
   :components ((:file "access")
                (:file "arg-list-manipulation"))
-  :depends-on ("iterate" "closer-mop" "alexandria" "anaphora" "cl-ppcre")
+  :depends-on ("iterate" "closer-mop" "alexandria" "cl-ppcre")
   :in-order-to ((test-op (load-op "access/test")))
   :perform (test-op (op c) (symbol-call '#:access-test '#:run-all-tests)))
 

--- a/access.lisp
+++ b/access.lisp
@@ -573,7 +573,7 @@
    eg: (accesses o k1 k2) => (access (access o k1) k2)"
   (iter (for k in keys)
     (destructuring-bind (k &key type test key)
-        (alexandria:ensure-list k)
+        (ensure-list k)
       (setf o (access o k :test test :type type :key key ))))
   o)
 
@@ -586,7 +586,7 @@
   "
   (labels ((rec-set (o key more)
              (destructuring-bind (k &key type test key)
-                 (alexandria:ensure-list key)
+                 (ensure-list key)
                ;(unless test (setf test #'equalper))
                ;(unless key (setf key #'identity))
                (cond

--- a/access.lisp
+++ b/access.lisp
@@ -67,26 +67,26 @@
    (format-args :accessor format-args :initarg :format-args :initform nil)
    (original-error :accessor original-error :initarg :original-error :initform nil))
   (:report (lambda (c s)
-	     (apply #'format
-	      s
-	      (format-control c)
-	      (format-args c)))))
+         (apply #'format
+          s
+          (format-control c)
+          (format-args c)))))
 
 (define-condition access-warning (warning access-condition) ())
 
 (defun access-warn (message &rest args)
   (warn (make-condition 'access-warning
-			:format-control message
-			:format-args args)))
+            :format-control message
+            :format-args args)))
 
 (defun equalper (x y)
   "compares symbols by equalp symbol-name"
   (flet ((cast (it)
-	   (typecase it
-	     (symbol (string it))
-	     (t it))))
+       (typecase it
+         (symbol (string it))
+         (t it))))
     (or (eql x y)
-	(equalp (cast x) (cast y)))))
+    (equalp (cast x) (cast y)))))
 
 (defvar *default-test* #'access:equalper)
 (defvar *default-key* #'identity)
@@ -167,17 +167,17 @@
 
 (defun %slot-writers (slots)
   (iter (for slot in (ensure-list slots))
-	(for sn = (closer-mop::slot-definition-name slot))
-	;; effective slots dont have readers or writers
-	;; but direct slots do, no idea why, I asked and its in the spec
+    (for sn = (closer-mop::slot-definition-name slot))
+    ;; effective slots dont have readers or writers
+    ;; but direct slots do, no idea why, I asked and its in the spec
     (for wn = (or (and (typep slot 'closer-mop:direct-slot-definition)
                        (first (closer-mop::slot-definition-writers slot)))
                   `(setf ,sn)))
-	(collecting wn into writer-names)
-	(collecting sn into slot-names)
-	;; some valid slot names are not valid function names (see type)
-	(collecting (ignore-errors (fdefinition wn)) into writers)
-	(finally (return (values writers writer-names slot-names)))))
+    (collecting wn into writer-names)
+    (collecting sn into slot-names)
+    ;; some valid slot names are not valid function names (see type)
+    (collecting (ignore-errors (fdefinition wn)) into writers)
+    (finally (return (values writers writer-names slot-names)))))
 
 (defun class-of-object ( o )
   "returns the class of the object/symbol (or itself if it is a class),
@@ -345,15 +345,15 @@
   "If we find a setf function named (setf fn) that can operate on o then call
    that with value new "
   (handler-bind ((undefined-function
-		  (lambda (c) (declare (ignore c))
-		    (return-from setf-if-applicable nil))))
+          (lambda (c) (declare (ignore c))
+            (return-from setf-if-applicable nil))))
     (setf fn
-	  (typecase fn
-	    ((or keyword string symbol closer-mop:slot-definition)
+      (typecase fn
+        ((or keyword string symbol closer-mop:slot-definition)
              (has-writer? o fn))
-	    (function fn)
+        (function fn)
             ((or number list) nil);; compound-keys and indexes
-	    (T (access-warn "Not sure how to call a ~A" fn) ))))
+        (T (access-warn "Not sure how to call a ~A" fn) ))))
   (etypecase fn
     (null nil)
     (standard-generic-function
@@ -371,12 +371,12 @@
                    (lambda (c) (declare (ignore c))
                      (return-from call-if-applicable nil))))
     (setf fn
-	  (typecase fn
-	    ((or keyword string closer-mop:slot-definition) (has-reader? o fn))
-	    (symbol (symbol-function fn))
-	    (function fn)
+      (typecase fn
+        ((or keyword string closer-mop:slot-definition) (has-reader? o fn))
+        (symbol (symbol-function fn))
+        (function fn)
             ((or number list) nil);; compound-keys and indexes
-	    (T (when warn-if-not-a-fn?
+        (T (when warn-if-not-a-fn?
                  (access-warn "Not sure how to call a ~A" fn))))))
 
   (handler-case
@@ -391,7 +391,7 @@
 (defun call-applicable-fns (o &rest fns)
   "For an object and a list of fn/fn names, call-if-applicable repeatedly"
   (iter (for fn in fns)
-	(setf o (call-if-applicable o fn)))
+    (setf o (call-if-applicable o fn)))
   o)
 
 (defgeneric do-access  (o k &key test key type skip-call?)
@@ -419,7 +419,7 @@
           (values res found)
           (awhen (ignore-errors (string k))
             (gethash it o)))))
-  
+
   (:method (o  k &key (test (default-test)) (key (default-key))
                  type skip-call?)
     ;; not specializing on standard-object here
@@ -470,13 +470,13 @@
            (make-instance type))))))
 
 (defgeneric do-set-access (new o k &key type test key)
-  
+
   ;; always return the new value as the first value
   ;; every primary method should return the modified object
   (:method :around (new o k &key type test key)
     (declare (ignore o k type test key))
     (values new (call-next-method)))
-  
+
   (:method (new (o list) k &key type test key )
     (if (or (eql type :alist)
             (and (null type) (consp (first o))))
@@ -488,7 +488,7 @@
         ;;plist
         (set-plist-val new k o :test test :key key)
         ))
-  
+
   (:method (new (o array) k &key type test key)
     (declare (ignore type test key))
     (setf (apply #'aref o (ensure-list k)) new)
@@ -507,7 +507,7 @@
             (sfound (setf (gethash skey o) new))
             (T (setf (gethash k o) new))))))
     o)
-  
+
   (:method (new (o standard-object) k &key type test key)
     (declare (ignore type test key))
     (let ((actual-slot-name (has-slot? o k)))
@@ -622,21 +622,21 @@
 (defun access-copy (from to keys)
   "Copy the values on 'from' to 'to' for all of the keys listed  "
   (iter (for k in keys)
-	(for (k1 k2) = (if (listp k) k (list k k)))
-	(setf (access to k2) (access from k1))))
+    (for (k1 k2) = (if (listp k) k (list k k)))
+    (setf (access to k2) (access from k1))))
 
 (defmacro with-access ((&rest keys) val-form &body body)
   "Similar to with-accessors except using the access functions"
   (let* ((gval (gensym "val"))
-	 (forms
-	  (iter (for k in keys)
-		(for (k-to k-from) = (if (listp k) k (list k k)))
-		(collect `(,k-to (access ,gval ',k-from))))))
+     (forms
+      (iter (for k in keys)
+        (for (k-to k-from) = (if (listp k) k (list k k)))
+        (collect `(,k-to (access ,gval ',k-from))))))
     `(let ((,gval ,val-form))
        (declare (ignorable ,gval))
        (symbol-macrolet (,@forms)
-	 ,@body
-	 ))))
+     ,@body
+     ))))
 
 (defun %create-accessor-symbol-list (class)
   "Gets the slots off a class an builds binding like  (local::symbol orig::symbol)
@@ -644,8 +644,8 @@
 
    used in with-all-slot-accessors"
   (let ((class (etypecase class
-		 (symbol (find-class class))
-		 (standard-class class))))
+         (symbol (find-class class))
+         (standard-class class))))
     (closer-mop:ensure-finalized class)
     (iter (for slot-name in (class-slot-names class))
       ;; collect bindings of local-symbol to class-slot-name
@@ -741,16 +741,16 @@
 
 (defun translate-dot-sym (sym)
   (let* ((pieces (split-dot-sym sym))
-	 (fns (iter (for sym in (rest pieces))
-		    (collect `(quote ,sym)))))
+     (fns (iter (for sym in (rest pieces))
+            (collect `(quote ,sym)))))
     (if (eql 1 (length pieces))
-	sym
-	`(accesses ,(first pieces) ,@fns))))
+    sym
+    `(accesses ,(first pieces) ,@fns))))
 
 (defun dot-translate-walker (form)
   (typecase form
     (cons (cons (dot-translate-walker (car form))
-		(dot-translate-walker (cdr form))))
+        (dot-translate-walker (cdr form))))
     (symbol (translate-dot-sym form))
     (atom form)))
 
@@ -782,7 +782,7 @@ readtable on stack."
   (values))
 
 (defun %disable-dot-syntax ()
-  "Internal function used to restore previous readtable." 
+  "Internal function used to restore previous readtable."
   (if *dot-previous-readtables*
     (setq *readtable* (pop *dot-previous-readtables*))
     (setq *readtable* (copy-readtable nil)))
@@ -798,4 +798,3 @@ readtable on stack."
 readtable is used."
   `(eval-when (:compile-toplevel :load-toplevel :execute)
     (%disable-dot-syntax)))
-

--- a/access.lisp
+++ b/access.lisp
@@ -1,6 +1,6 @@
-(cl:defpackage :access
-  (:use :cl :cl-user :iterate)
-  (:shadowing-import-from :alexandria #:ensure-list #:if-let #:when-let)
+(cl:defpackage #:access
+  (:use #:cl #:iterate)
+  (:import-from #:alexandria #:ensure-list #:if-let #:when-let)
   (:export
    #:access-warning
    ;; utils to make this work

--- a/test/access.lisp
+++ b/test/access.lisp
@@ -74,8 +74,8 @@
       (assert-equal value nil)
       (assert-equal present-p nil))
     (assert-equal
-        (list "something" "5" "four" "three" "two" "one")
-        (access +ht+ 'hash-table-keys))
+     (list "5" "four" "one" "something" "three" "two")
+     (sort (access +ht+ 'hash-table-keys) 'string<))
     (assert-equal 3 (accesses o 'pl 'three ))))
 
 (define-test test-with-access ()

--- a/test/access.lisp
+++ b/test/access.lisp
@@ -1,9 +1,9 @@
 (cl:defpackage :access-test
-  (:use :cl :cl-user :iterate :access :lisp-unit2))
+  (:use #:cl #:iterate #:lisp-unit2)
+  (:use #:access))
 
 ;; for a specific test
-(cl:defpackage :access-test-other
-  (:use :cl :cl-user :iterate :access :lisp-unit2))
+(cl:defpackage :access-test-other)
 
 (in-package :access-test)
 

--- a/test/access.lisp
+++ b/test/access.lisp
@@ -1,13 +1,9 @@
 (cl:defpackage :access-test
-  (:use :cl :cl-user :iterate :access :lisp-unit2)
-  (:shadowing-import-from :alexandria #:ensure-list )
-  (:shadowing-import-from :anaphora #:awhen #:aif #:it)
-  (:export ))
+  (:use :cl :cl-user :iterate :access :lisp-unit2))
 
 ;; for a specific test
 (cl:defpackage :access-test-other
-  (:use :cl :cl-user :iterate :access :lisp-unit2)
-  (:export ))
+  (:use :cl :cl-user :iterate :access :lisp-unit2))
 
 (in-package :access-test)
 

--- a/test/access.lisp
+++ b/test/access.lisp
@@ -118,7 +118,7 @@
     (assert-equal 333 (access +ht+ 'three))
     (assert-equal 333 (access +ht+ "three"))
     (setf (access +ht+ 'three) 3)
-    
+
     (assert-equal nil (access +ht+ "sixteen"))
     (setf (access +ht+ "sixteen") 16)
     (assert-equal 16 (access +ht+ 'sixteen))
@@ -198,10 +198,10 @@
 (define-test dot-iteration ()
   (with-dot ()
     (iter (for (k v . rest) on (list :pl1 +pl+ :pl2 +pl+) by #'cddr)
-	  (when (first-iteration-p)
-	    (assert-equal 12 rest.pl2.length)
-	    (assert-equal 4 rest.pl2.four))
-	  (assert-equal 4 v.four))))
+      (when (first-iteration-p)
+        (assert-equal 12 rest.pl2.length)
+        (assert-equal 4 rest.pl2.four))
+      (assert-equal 4 v.four))))
 
 ;; sbcl started raising (rightly) style warnings about this
 (handler-bind ((style-warning #'muffle-warning))
@@ -295,7 +295,7 @@
   (assert-true (has-writer? +mop+ '(setf :slot-a)))
   (assert-true (has-writer? +mop+ '(setf "slot-a")))
   (assert-true (has-writer? +mop+ "(setf slot-a)"))
-  
+
   (assert-false (has-writer? +mop+ "slot-d"))
   (assert-false (has-writer? +mop+ 'slot-d))
   (assert-false (has-writer? +mop+ :slot-d)))

--- a/test/access.lisp
+++ b/test/access.lisp
@@ -1,6 +1,10 @@
 (cl:defpackage :access-test
   (:use #:cl #:iterate #:lisp-unit2)
-  (:use #:access))
+  (:use #:access)
+  (:import-from #:alexandria
+                #:plist-hash-table
+                #:hash-table-keys
+                #:copy-hash-table))
 
 ;; for a specific test
 (cl:defpackage :access-test-other)
@@ -29,7 +33,7 @@
 (defparameter +al+ `((:one . 1) ("two" . 2) ("three" . 3) (four . 4) (:5 . 5) (:something . nil)))
 (defparameter +pl+ (list :one 1 "two" 2 "three" 3 'four 4 :5 5 :something nil))
 (defparameter +ht+
-  (alexandria::plist-hash-table
+  (plist-hash-table
    (list "one" 1 "two" 2 "three" 3 "four" 4 "5" 5 "something" nil)
    :test 'equalp))
 
@@ -71,7 +75,7 @@
       (assert-equal present-p nil))
     (assert-equal
         (list "something" "5" "four" "three" "two" "one")
-        (access +ht+ 'alexandria:hash-table-keys))
+        (access +ht+ 'hash-table-keys))
     (assert-equal 3 (accesses o 'pl 'three ))))
 
 (define-test test-with-access ()
@@ -108,7 +112,7 @@
     (assert-equal 16 (access pl 'sixteen))))
 
 (define-test access-and-setting-hashtable ()
-  (let ((+ht+ (alexandria:copy-hash-table +ht+) ))
+  (let ((+ht+ (copy-hash-table +ht+) ))
     (assert-equal 3 (access +ht+ 'three))
     (setf (access +ht+ 'three) 333)
     (assert-equal 333 (access +ht+ 'three))


### PR DESCRIPTION
Merge this after #14 

This removes the dependency on 'anaphora' because access only uses basic AIF / AWHEN, and these can easily be replaced by alexandria's IF-LET / WHEN-LET helpers. Just one less dependency to worry about.

The PR also includes a bunch of other fixes related to package definitions and a fix for a portability issue. I'm sorry for just dumping all of these changes in here, but please consider that you'd have to review many more PRs if I had split this up.