### PR TITLE
access hash-table: also try key as string, downcased.

### DIFF
--- a/access.lisp
+++ b/access.lisp
@@ -420,8 +420,10 @@
     (multiple-value-bind (res found) (gethash k o)
       (if found
           (values res found)
-          (when-let (skey (ignore-errors (string k)))
-            (gethash skey o)))))
+          (let ((skey (ignore-errors (string k)))
+                (downcase-skey (ignore-errors (string-downcase (string k)))))
+            (or (and skey (gethash skey o))
+                (and downcase-skey (gethash downcase-skey o)))))))
 
   (:method (o  k &key (test (default-test)) (key (default-key))
                  type skip-call?)


### PR DESCRIPTION
Use case: Djula templates. An access such as `{{ product.title }}` will now work with hash-tables containing "title" as a string, lower-case. 

```lisp
(dict  "id" 828  "title" "Lisp book")
```

Best,